### PR TITLE
First implementation

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -1,0 +1,4 @@
+package otrestful
+
+const DefaultComponentName = "emicklei/go-restful"
+const DefaultOperationName = "go-restful client"

--- a/example/client.go
+++ b/example/client.go
@@ -1,0 +1,40 @@
+// +build go1.7
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/opentracing-contrib/go-restful"
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
+)
+
+func main() {
+	// 1) Create a opentracing.Tracer that sends data to Zipkin
+	collector, _ := zipkin.NewHTTPCollector(fmt.Sprintf("http://127.0.0.1:9411/api/v1/spans"))
+	tracer, _ := zipkin.NewTracer(
+		zipkin.NewRecorder(collector, true, "0.0.0.0:0", "trivial"))
+
+	// 2) Demonstrate nethttp client-side OpenTracing instrumentation works
+	client := &http.Client{Transport: &nethttp.Transport{}}
+	req, err := http.NewRequest("GET", "http://127.0.0.1:8080/hello", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req, ht := nethttp.TraceRequest(tracer, req,
+		nethttp.OperationName(otrestful.DefaultOperationName), nethttp.ComponentName(otrestful.DefaultComponentName))
+
+	_, err = client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ht.Finish()
+
+	// ... give Zipkin ample time to flush
+	time.Sleep(2 * time.Second)
+}

--- a/example/server.go
+++ b/example/server.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+	"github.com/opentracing-contrib/go-restful"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
+)
+
+func main() {
+	// 1) Create a opentracing.Tracer that sends data to Zipkin
+	collector, _ := zipkin.NewHTTPCollector(fmt.Sprintf("http://127.0.0.1:9411/api/v1/spans"))
+	// set tracer
+	otrestful.Tracer, _ = zipkin.NewTracer(
+		zipkin.NewRecorder(collector, true, "0.0.0.0:0", "trivial"))
+
+	// install a global (=DefaultContainer) filter (processed before any webservice in the DefaultContainer)
+	// to provide  OpenTracing instrument
+	restful.Filter(otrestful.OTFilter)
+
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/hello").To(hello))
+
+	restful.Add(ws)
+	http.ListenAndServe(":8080", nil)
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "world")
+}

--- a/example/server.go
+++ b/example/server.go
@@ -13,13 +13,12 @@ import (
 func main() {
 	// 1) Create a opentracing.Tracer that sends data to Zipkin
 	collector, _ := zipkin.NewHTTPCollector(fmt.Sprintf("http://127.0.0.1:9411/api/v1/spans"))
-	// set tracer
-	otrestful.Tracer, _ = zipkin.NewTracer(
+	tracer, _ := zipkin.NewTracer(
 		zipkin.NewRecorder(collector, true, "0.0.0.0:0", "trivial"))
 
 	// install a global (=DefaultContainer) filter (processed before any webservice in the DefaultContainer)
 	// to provide  OpenTracing instrument
-	restful.Filter(otrestful.OTFilter)
+	restful.Filter(otrestful.NewOTFilter(tracer))
 
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/hello").To(hello))

--- a/ot_filter.go
+++ b/ot_filter.go
@@ -1,0 +1,50 @@
+package otrestful
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// go-restful FilterFunction does not allow to opt in third-party parameters,
+// so using global variables for the moment
+// TODO(mqliang): using parameter instead of global variable to set this
+var (
+	Tracer            opentracing.Tracer
+	OperationNameFunc func(r *restful.Request) string
+	ComponentName     string
+)
+
+var (
+	DefaulOperationNameFunc = func(r *restful.Request) string {
+		return "HTTP " + r.Request.Method
+	}
+)
+
+// OTFilter if a filter which add OpenTracing instrument
+// "filter" in go-restful is similar with "middleware" mechanism in modern web framework
+func OTFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	defer chain.ProcessFilter(req, resp)
+	if Tracer == nil {
+		// if Tracer global variable is nil, skip tracing
+		return
+	}
+	ctx, _ := Tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Request.Header))
+	if OperationNameFunc == nil {
+		OperationNameFunc = DefaulOperationNameFunc
+	}
+	// record operation name
+	sp := Tracer.StartSpan(OperationNameFunc(req), ext.RPCServerOption(ctx))
+	// record HTTP method
+	ext.HTTPMethod.Set(sp, req.Request.Method)
+	// record HTTP url
+	ext.HTTPUrl.Set(sp, req.Request.URL.String())
+	// record component name
+	if ComponentName == "" {
+		ComponentName = DefaultComponentName
+	}
+	ext.Component.Set(sp, ComponentName)
+	// record HTTP status code
+	ext.HTTPStatusCode.Set(sp, uint16(resp.StatusCode()))
+	sp.Finish()
+}

--- a/ot_filter.go
+++ b/ot_filter.go
@@ -6,45 +6,62 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// go-restful FilterFunction does not allow to opt in third-party parameters,
-// so using global variables for the moment
-// TODO(mqliang): using parameter instead of global variable to set this
 var (
-	Tracer            opentracing.Tracer
-	OperationNameFunc func(r *restful.Request) string
-	ComponentName     string
-)
-
-var (
-	DefaulOperationNameFunc = func(r *restful.Request) string {
-		return "HTTP " + r.Request.Method
+	DefaultOperationNameFunc = func(r *restful.Request) string {
+		// extract the route that the request maps to and use it as the operation name.
+		return r.SelectedRoutePath()
 	}
 )
 
-// OTFilter if a filter which add OpenTracing instrument
-// "filter" in go-restful is similar with "middleware" mechanism in modern web framework
-func OTFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-	defer chain.ProcessFilter(req, resp)
-	if Tracer == nil {
-		// if Tracer global variable is nil, skip tracing
-		return
+type filterOptions struct {
+	operationNameFunc func(r *restful.Request) string
+	componentName     string
+}
+
+// FilterOption controls the behavior of the Filter.
+type FilterOption func(*filterOptions)
+
+// OperationNameFunc returns a FilterOption that uses given function f
+// to generate operation name for each server-side span.
+func OperationNameFunc(f func(r *restful.Request) string) FilterOption {
+	return func(options *filterOptions) {
+		options.operationNameFunc = f
 	}
-	ctx, _ := Tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Request.Header))
-	if OperationNameFunc == nil {
-		OperationNameFunc = DefaulOperationNameFunc
+}
+
+// ComponentName returns a FilterOption that sets the component name
+// name for the server-side span.
+func ComponentName(componentName string) FilterOption {
+	return func(options *filterOptions) {
+		options.componentName = componentName
 	}
-	// record operation name
-	sp := Tracer.StartSpan(OperationNameFunc(req), ext.RPCServerOption(ctx))
-	// record HTTP method
-	ext.HTTPMethod.Set(sp, req.Request.Method)
-	// record HTTP url
-	ext.HTTPUrl.Set(sp, req.Request.URL.String())
-	// record component name
-	if ComponentName == "" {
-		ComponentName = DefaultComponentName
+}
+
+// NewOTFilter returns a go-restful filter which add OpenTracing instrument
+func NewOTFilter(tracer opentracing.Tracer, options ...FilterOption) restful.FilterFunction {
+	opts := filterOptions{
+		operationNameFunc: DefaultOperationNameFunc,
+		componentName:     DefaultComponentName,
 	}
-	ext.Component.Set(sp, ComponentName)
-	// record HTTP status code
-	ext.HTTPStatusCode.Set(sp, uint16(resp.StatusCode()))
-	sp.Finish()
+	for _, opt := range options {
+		opt(&opts)
+	}
+
+	// return a go-restful filter which add OpenTracing instrument
+	// NOTE: "filter" in go-restful is similar with "middleware" mechanism in modern web framework
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		defer chain.ProcessFilter(req, resp)
+		ctx, _ := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Request.Header))
+		// record operation name
+		sp := tracer.StartSpan(opts.operationNameFunc(req), ext.RPCServerOption(ctx))
+		// record HTTP method
+		ext.HTTPMethod.Set(sp, req.Request.Method)
+		// record HTTP url
+		ext.HTTPUrl.Set(sp, req.Request.URL.String())
+		// record component name
+		ext.Component.Set(sp, opts.componentName)
+		// record HTTP status code
+		ext.HTTPStatusCode.Set(sp, uint16(resp.StatusCode()))
+		sp.Finish()
+	}
 }


### PR DESCRIPTION
@wu-sheng @tedsuo 

This pr:
1) add a filter (middleware) for OpenTracing instrumentation
2) add client side and server side example

Note:
1) go-restful framework does not provide custom client, so client side instrumentation is not needed. User can use go stdlib(which already has OT instrumentation) to send request. I also fix a issue in the go stdlib instrumentation, see  https://github.com/opentracing-contrib/go-stdlib/pull/13

2) since go-restful "filter" interface does not allow user to opt in arguments, so I use global variables to pass arguments. 

3) unit-test has not provided. I manually run the example and it turns out instrumentation works. 
Will add unit-test if this implementation is in the right direction.